### PR TITLE
CosmosDB documentation: Fixed JS and YML indentation

### DIFF
--- a/docs/providers/azure/events/cosmosdb.md
+++ b/docs/providers/azure/events/cosmosdb.md
@@ -35,16 +35,22 @@ functions:
     handler: src/handlers/cosmos.write
     events:
       - http: true
-        methods:
-          - POST
-        authLevel: anonymous
+        x-azure-settings:
+          methods:
+            - POST
+          authLevel: anonymous
+      - http: true
+        x-azure-settings:
+          direction: out
+          name: res
       - cosmosDB:
-        direction: out
-        name: record # name of input parameter in function signature
-        databaseName: sampleDB
-        collectionName: sampleCollection
-        connectionStringSetting: COSMOS_DB_CONNECTION # name of appsetting with the connection string
-        createIfNotExists: true # A boolean value to indicate whether the collection is created when it doesn't exist.
+        x-azure-settings:
+          direction: out
+          name: record # name of input parameter in function signature
+          databaseName: sampleDB
+          collectionName: sampleCollection
+          connectionStringSetting: COSMOS_DB_CONNECTION # name of appsetting with the connection string
+          createIfNotExists: true # A boolean value to indicate whether the collection is created when it doesn't exist.
 ```
 
 ## Sample post data
@@ -65,13 +71,13 @@ functions:
 'use strict';
 const uuidv4 = require('uuid/v4');
 
-module.exports.write = async function(context, req) {
+module.exports.write = async function (context, req) {
   context.log('JavaScript HTTP trigger function processed a request.');
 
   const input = req.body;
 
   const timestamp = Date.now();
-  const uuid = uuidv4(); //
+  const uuid = uuidv4();
 
   const output = JSON.stringify({
     id: uuid,
@@ -84,5 +90,10 @@ module.exports.write = async function(context, req) {
   context.bindings.record = output;
 
   context.log('Finish writing to CosmosDB');
+
+  context.res = {
+    status: 201,
+    body: 'Created',
+  };
 };
 ```


### PR DESCRIPTION
Coming from PR-#7569 fixed prettier formatting for js and yml code in cosmosdb documentation as suggested by @medikoo.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #7569
